### PR TITLE
Fix fork me ribbon

### DIFF
--- a/views/layout.pug
+++ b/views/layout.pug
@@ -29,7 +29,7 @@ html
         a(href="/") wikistream
 
     a(id="github", target="_blank", href="http://github.com/toolforge/wikistream")
-      img(style="position: absolute; top: 0; right: 0; border: 0; z-index: 3;", src="https://tools.wmflabs.org/static/res/logos/forkme_right_darkblue.png", alt="Fork me on GitHub")
+      img(style="position: absolute; top: 0; right: 0; border: 0; z-index: 3;", src="https://github.blog/wp-content/uploads/2008/12/forkme_right_darkblue_121621.png?resize=149%2C149", alt="Fork me on GitHub")
     br
     div(id="content")
       block content


### PR DESCRIPTION
Replaced fork me on GitHub ribbon file URL; Fixes #1.

cf: https://github.blog/2008-12-19-github-ribbons/